### PR TITLE
fix: when opening dicom files they were not sorted by z-position

### DIFF
--- a/iSeg/SlicesHandler.cpp
+++ b/iSeg/SlicesHandler.cpp
@@ -7755,6 +7755,12 @@ int SlicesHandler::LoadDICOM(std::vector<const char*> lfilename)
 		_os.set_sizenr(_nrslices);
 		_image_slices.resize(_nrslices);
 
+		// make sure files are sorted according to z-position
+		if (lfilename.size() > 1)
+		{
+			DICOMsort(&lfilename);
+		}
+
 		_activeslice = 0;
 		_active_tissuelayer = 0;
 		_startslice = 0;


### PR DESCRIPTION
fix: when opening dicom files they were sorted according to (lexicographic) ordering of "open file dialog"

-> now they are sorted by z-position