### PR TITLE
Make settings folder configurable

### DIFF
--- a/Interface/RecentPlaces.cpp
+++ b/Interface/RecentPlaces.cpp
@@ -14,6 +14,7 @@
 #include <QFileInfo>
 #include <QList>
 #include <QUrl>
+#include <QProcessEnvironment>
 
 namespace iseg {
 
@@ -98,7 +99,8 @@ QString RecentPlaces::LastDirectory()
 {
 	if (!list.empty())
 		return list.front();
-	return QDir::home().absolutePath();
+	
+	return QProcessEnvironment::systemEnvironment().value("ISEG_DEFAULT_LAST_DIR", QDir::home().absolutePath());
 }
 
 std::deque<QString> RecentPlaces::RecentDirectories()

--- a/iSeg/main.cpp
+++ b/iSeg/main.cpp
@@ -36,6 +36,7 @@
 #include <QMessageBox>
 #include <QSplashScreen>
 #include <QVBoxLayout>
+#include <QProcessEnvironment>
 
 #include <boost/date_time.hpp>
 #include <boost/filesystem.hpp>
@@ -142,7 +143,10 @@ int main(int argc, char** argv)
 	QString splashpicpath = picpath.absoluteFilePath("splash.png");
 	QString locationpath = file_directory.absolutePath();
 	QString latestprojpath = tmpdir.absoluteFilePath("latestproj.txt");
-	QString settingspath = tmpdir.absoluteFilePath("settings.bin");
+
+	QDir settings_dir = QDir(QProcessEnvironment::systemEnvironment().value("ISEG_SETTINGS_DIR", tmpdir.absolutePath()));
+
+	QString settingspath = settings_dir.absoluteFilePath("settings.bin");
 
 	TissueInfos::InitTissues();
 	BranchItem::InitAvailablelabels();


### PR DESCRIPTION
- If `settings.bin` sits inside the `workspace` folder in `osparc`, the arrangements of windows can be kept persistent. This is done via a env var.
- Do the same for the default last directory path