### PR TITLE
CI: update runner to ubuntu-22.04, checkout@v4, drop Kitware PPA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,19 +9,17 @@ on:
 
 jobs:
   build-and-test:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install thirdparties
         run: |
-          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
-          sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
           sudo apt-get update
-          sudo apt install -y cmake 
+          sudo apt install -y cmake
           sudo apt install -y libboost-filesystem-dev libboost-test-dev libboost-date-time-dev libboost-program-options-dev
           sudo apt install -y libhdf5-dev
           sudo apt install -y libeigen3-dev
-          sudo add-apt-repository ppa:rock-core/qt4
+          sudo add-apt-repository -y ppa:ubuntuhandbook1/ppa
           sudo apt-get update
           sudo apt install -y libqt4-opengl-dev
           mkdir -p deps


### PR DESCRIPTION
ubuntu-20.04 runners are deprecated. System cmake 3.22 on 22.04 is sufficient (project requires 3.12).