### PR TITLE
Add DataIteratorWidget, orientation support, and surface viewer fixes

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -32,6 +32,7 @@ SET(SOURCES
 	ImageWriter.cpp
 	IndexPriorityQueue.cpp
 	InitializeITKFactory.cpp
+	itkDICOMOrientation.cxx
 	KMeans.cpp
 	LoadPlugin.cpp
 	Log.cpp

--- a/Core/ImageReader.cpp
+++ b/Core/ImageReader.cpp
@@ -304,6 +304,12 @@ bool ImageReader::GetVolume(const std::string& filename, std::vector<float>& buf
 
 bool ImageReader::CopySlices(const std::vector<float>& buffer, float** slices, unsigned startslice, unsigned nrslices, unsigned width, unsigned height)
 {
+	const size_t required = static_cast<size_t>(startslice + nrslices) * width * height;
+	if (buffer.size() < required)
+	{
+		return false;
+	}
+
 	for (size_t k = 0; k < nrslices; k++)
 	{
 		size_t pos3d = (k + startslice) * width * height, pos = 0;

--- a/Core/ImageReader.cpp
+++ b/Core/ImageReader.cpp
@@ -14,6 +14,8 @@
 #include "ImageReader.h"
 #include "VTIreader.h"
 
+#include "itkDICOMOrientImageFilter.h"
+
 #include <itkImage.h>
 #include <itkImageFileReader.h>
 #include <itkRGBPixel.h>
@@ -222,6 +224,98 @@ bool ImageReader::GetInfo(const std::string& filename, unsigned& width, unsigned
 		}
 	}
 	return false;
+}
+
+bool ImageReader::GetVolume(const std::string& filename, std::vector<float>& buffer, unsigned& width, unsigned& height, unsigned& nrslices, float spacing[3], Transform& transform, eOrientation orientation)
+{
+	using image_type = itk::Image<float, 3>;
+	using reader_type = itk::ImageFileReader<image_type>;
+
+	auto reader = reader_type::New();
+	reader->SetFileName(filename);
+	try
+	{
+		reader->UpdateLargestPossibleRegion();
+	}
+	catch (itk::ExceptionObject&)
+	{
+		return false;
+	}
+
+	const unsigned int num_dim = (reader->GetImageIO() != nullptr) ? reader->GetImageIO()->GetNumberOfDimensions() : 3;
+	typename reader_type::OutputImagePointer image = reader->GetOutput();
+
+	auto orient = itk::DICOMOrientImageFilter<image_type>::New();
+	if (orientation != eOrientation::noChange && num_dim == 3)
+	{
+		switch (orientation)
+		{
+		case eOrientation::RAS:
+			orient->SetDesiredCoordinateOrientation(itk::DICOMOrientation::OrientationEnum::RAS);
+			break;
+		case eOrientation::LPS:
+			orient->SetDesiredCoordinateOrientation(itk::DICOMOrientation::OrientationEnum::LPS);
+			break;
+		case eOrientation::LAS:
+			orient->SetDesiredCoordinateOrientation(itk::DICOMOrientation::OrientationEnum::LAS);
+			break;
+		case eOrientation::PSL:
+			orient->SetDesiredCoordinateOrientation(itk::DICOMOrientation::OrientationEnum::PSL);
+			break;
+		case eOrientation::RSP:
+			orient->SetDesiredCoordinateOrientation(itk::DICOMOrientation::OrientationEnum::RSP);
+			break;
+		default:
+			orient->SetDesiredCoordinateOrientation(itk::DICOMOrientation::OrientationEnum::RAS);
+			break;
+		}
+
+		orient->SetInput(reader->GetOutput());
+		orient->UpdateLargestPossibleRegion();
+		image = orient->GetOutput();
+	}
+
+	// copy dimension
+	const auto region = image->GetLargestPossibleRegion();
+	const itk::SizeValueType dims[3] = {region.GetSize()[0], region.GetSize()[1], region.GetSize()[2]};
+
+	width = static_cast<unsigned>(dims[0]);
+	height = static_cast<unsigned>(dims[1]);
+	nrslices = (num_dim == 3) ? static_cast<unsigned>(dims[2]) : 1;
+
+	// copy transform & spacing
+	transform.SetIdentity();
+	for (unsigned int r = 0; r < num_dim; r++)
+	{
+		spacing[r] = static_cast<float>(image->GetSpacing()[r]);
+		for (unsigned int c = 0; c < num_dim; c++)
+			transform[r][c] = image->GetDirection()[r][c];
+		transform[r][3] = image->GetOrigin()[r];
+	}
+
+	// copy buffer
+	auto container = image->GetPixelContainer();
+	const image_type::PixelType* import_buffer = container->GetImportPointer();
+	const auto buffer_length = region.GetNumberOfPixels();
+	buffer.assign(import_buffer, import_buffer + buffer_length);
+
+	return true;
+}
+
+bool ImageReader::CopySlices(const std::vector<float>& buffer, float** slices, unsigned startslice, unsigned nrslices, unsigned width, unsigned height)
+{
+	for (size_t k = 0; k < nrslices; k++)
+	{
+		size_t pos3d = (k + startslice) * width * height, pos = 0;
+		for (unsigned j = 0; j < height; j++)
+		{
+			for (unsigned i = 0; i < width; i++, pos++, pos3d++)
+			{
+				slices[k][pos] = buffer[pos3d];
+			}
+		}
+	}
+	return true;
 }
 
 } // namespace iseg

--- a/Core/ImageReader.h
+++ b/Core/ImageReader.h
@@ -19,6 +19,15 @@ namespace iseg {
 
 class Transform;
 
+enum class eOrientation {
+	noChange = 0, // don't permute axes, preserve file ordering
+	RAS,          // axial (Neurologist/Neuroimaging preferred)
+	LAS,          // axial, (Radiologist preferred)
+	LPS,          // ITK preferred
+	PSL,          // sagittal
+	RSP,          // coronal
+};
+
 /** \brief Image reader based on ITK image reader factory
 	*/
 class ISEG_CORE_API ImageReader
@@ -41,6 +50,15 @@ public:
 	/// loads image into pre-allocated memory
 	static bool GetVolume(const std::string& filename, float** slices, unsigned nrslices, unsigned width, unsigned height);
 	static bool GetVolume(const std::string& filename, float** slices, unsigned startslice, unsigned nrslices, unsigned width, unsigned height);
+
+	/// loads image into buffer with optional orientation resampling
+	static bool GetVolume(const std::string& filename, std::vector<float>& buffer,
+			unsigned& width, unsigned& height, unsigned& nrslices,
+			float spacing[3], Transform& transform, eOrientation orient = eOrientation::noChange);
+
+	/// copies buffer to pre-allocated memory
+	static bool CopySlices(const std::vector<float>& buffer, float** slices,
+			unsigned startslice, unsigned nrslices, unsigned width, unsigned height);
 };
 
 } // namespace iseg

--- a/Core/itkDICOMOrientImageFilter.h
+++ b/Core/itkDICOMOrientImageFilter.h
@@ -1,0 +1,193 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkDICOMOrientImageFilter_h
+#define itkDICOMOrientImageFilter_h
+
+#include "itkDICOMOrientation.h"
+#include "itkPermuteAxesImageFilter.h"
+#include "itkFlipImageFilter.h"
+#include <map>
+#include <string>
+
+namespace itk
+{
+
+/** \class DICOMOrientImageFilter
+ * \brief Permute axes and flip images as needed to obtain an approximation to the desired orientation.
+ *
+ * The physical location of all pixels in the image remains the same, but the meta-data and the ordering of the stored
+ * pixels may change.
+ *
+ *
+ * DICOMOrientImageFilter depends on a set of constants that describe all possible labels. Directions are labeled in
+ * terms of following pairs:
+ *   - Left and Right (Subject's left and right)
+ *   - Anterior and Posterior (Subject's front and back)
+ *   - Inferior and Superior (Subject's bottom and top, i.e. feet and head)
+ *
+ * The initials of these directions are used in a 3 letter code in the enumerated type OrientationEnum. The initials are
+ * given fastest moving index first, second fastest second, third fastest third, where the label's direction indicates
+ * increasing values.
+ *
+ * An ITK image with an identity direction cosine matrix is in LPS (Left, Posterior, Superior) orientation as defined by
+ * the DICOM standard.
+ *
+ * \f[
+ * LPS = \begin{Bmatrix}
+ * from\ right\ to\ \textbf{L}eft \\
+ * from\ anterior\ towards\ \textbf{P}osterior  \\
+ * from\ inferior\ towards\ \textbf{S}uperior
+ * \end{Bmatrix}
+ * \f]
+ *
+ * The output orientation is specified with SetDesiredCoordinateOrientation. The input coordinate orientation is
+ * computed from the input image's direction cosine matrix.
+ *
+ * \ingroup SimpleITKFilters
+ */
+template <typename TInputImage>
+class DICOMOrientImageFilter : public ImageToImageFilter<TInputImage, TInputImage>
+{
+public:
+  /** Standard class type aliases. */
+  using Self = DICOMOrientImageFilter;
+  using Superclass = ImageToImageFilter<TInputImage, TInputImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Some convenient type alias. */
+  using ImageType = TInputImage;
+  using ImagePointer = typename ImageType::Pointer;
+  using ImageConstPointer = typename ImageType::ConstPointer;
+  using ImageRegionType = typename ImageType::RegionType;
+  using ImagePixelType = typename ImageType::PixelType;
+  using DirectionType = typename ImageType::DirectionType;
+
+  /** Axes permuter type. */
+  using PermuterType = PermuteAxesImageFilter<TInputImage>;
+  using PermuteOrderArrayType = typename PermuterType::PermuteOrderArrayType;
+
+  /** Axes flipper type. */
+  using FlipperType = FlipImageFilter<TInputImage>;
+  using FlipAxesArrayType = typename FlipperType::FlipAxesArrayType;
+
+  /** ImageDimension constants */
+  static constexpr unsigned int ImageDimension = ImageType::ImageDimension;
+
+  /** Standard New method. */
+  itkNewMacro(Self);
+
+  /** Runtime information support. */
+  itkTypeMacro(DICOMOrientImageFilter, ImageToImageFilter);
+
+  using OrientationEnum = DICOMOrientation::OrientationEnum;
+
+  /** Get the orientation codes that defines the input coordinate transform.
+   *
+   *  This value changes during the execution of the Update in the pipeline. */
+  itkGetEnumMacro(InputCoordinateOrientation, OrientationEnum);
+
+  /** Set/Get the desired coordinate orientation for the output image */
+  itkGetEnumMacro(DesiredCoordinateOrientation, OrientationEnum);
+  void
+  SetDesiredCoordinateOrientation(OrientationEnum newCode);
+  void
+  SetDesiredCoordinateOrientation(const std::string & desired);
+
+  /** Set Get the desired coordinate orientation from a direction matrix. */
+  inline void
+  SetDesiredCoordinateDirection(const typename ImageType::DirectionType & DesiredDirection)
+  {
+    SetDesiredCoordinateOrientation(DICOMOrientation::DirectionCosinesToOrientation(DesiredDirection));
+  }
+
+
+  /** Get axes permute order.
+   *
+   * This value is computed during Update.
+   * */
+  itkGetConstReferenceMacro(PermuteOrder, PermuteOrderArrayType);
+
+  /** Get flip axes.
+   *
+   * This value is computed during Update.
+   * */
+  itkGetConstReferenceMacro(FlipAxes, FlipAxesArrayType);
+
+
+  /** DICOMOrientImageFilter produces an image which is a different
+   *  meta-data than its input image.
+   * \sa ProcessObject::GenerateOutputInformation() */
+  void
+  GenerateOutputInformation() override;
+
+  static_assert(ImageDimension == 3, "Only 3 dimensional images are support!");
+
+protected:
+  DICOMOrientImageFilter();
+  ~DICOMOrientImageFilter() override = default;
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
+  /** OrientImageFilter will produce the entire output. */
+  void
+  GenerateInputRequestedRegion() override;
+
+  /*** Member functions used by GenerateData: */
+  void
+  DeterminePermutationsAndFlips(DICOMOrientation desired, DICOMOrientation given);
+
+  /** Returns true if a permute is required. Returns false otherwise. */
+  bool
+  NeedToPermute();
+
+  /** Returns true if flipping is required. Returns false otherwise. */
+  bool
+  NeedToFlip();
+
+
+  void
+  SetInputCoordinateOrientation(OrientationEnum newCode);
+
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
+  /** Single-threaded version of GenerateData. This filter delegates
+   * to PermuteAxesImageFilter and FlipImageFilter. */
+  void
+  GenerateData() override;
+
+private:
+  DICOMOrientImageFilter(const Self&) = delete;
+  void operator=(const Self&) = delete;
+
+  DICOMOrientation m_InputCoordinateOrientation{ OrientationEnum::INVALID };
+  DICOMOrientation m_DesiredCoordinateOrientation{ OrientationEnum::LPS };
+
+  PermuteOrderArrayType m_PermuteOrder;
+  FlipAxesArrayType     m_FlipAxes =  false ;
+
+}; // end of class
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkDICOMOrientImageFilter.hxx"
+#endif
+
+#endif

--- a/Core/itkDICOMOrientImageFilter.hxx
+++ b/Core/itkDICOMOrientImageFilter.hxx
@@ -1,0 +1,321 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkDICOMOrientImageFilter_hxx
+#define itkDICOMOrientImageFilter_hxx
+
+#include "itkDICOMOrientImageFilter.h"
+#include "itkPermuteAxesImageFilter.h"
+#include "itkFlipImageFilter.h"
+#include "itkCastImageFilter.h"
+#include "itkProgressAccumulator.h"
+
+namespace itk
+{
+
+template <typename TInputImage>
+DICOMOrientImageFilter<TInputImage>::DICOMOrientImageFilter()
+{
+  for (unsigned int dimension = 0; dimension < ImageDimension; ++dimension)
+  {
+    this->m_PermuteOrder[dimension] = dimension;
+  }
+}
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::GenerateInputRequestedRegion()
+{
+  Superclass::GenerateInputRequestedRegion();
+
+  // Get pointers to the input and output
+  typename ImageType::Pointer inputPtr = const_cast<ImageType *>(this->GetInput());
+  if (inputPtr)
+  {
+    inputPtr->SetRequestedRegionToLargestPossibleRegion();
+  }
+}
+
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::DeterminePermutationsAndFlips(DICOMOrientation desired, DICOMOrientation given)
+{
+  for (unsigned int j = 0; j < ImageDimension; j++)
+  {
+    m_PermuteOrder[j] = j;
+  }
+
+  m_FlipAxes.Fill(false);
+
+  constexpr unsigned int CodeAxisDir = 0x1;
+
+  const DICOMOrientation::CoordinateEnum desired_codes[] = { desired.GetPrimaryTerm(),
+                                                             desired.GetSecondaryTerm(),
+                                                             desired.GetTertiaryTerm() };
+  const DICOMOrientation::CoordinateEnum given_codes[] = { given.GetPrimaryTerm(),
+                                                           given.GetSecondaryTerm(),
+                                                           given.GetTertiaryTerm() };
+
+  // i, j, k will be the indexes in the Majorness code of the axes to flip;
+  // they encode the axes as the reader will find them, 0 is the lowest order
+  // axis of whatever spatial interpretation, and 2 is the highest order axis.
+  //  Perhaps rename them moving_image_reader_axis_i, etc.
+
+  for (unsigned int i = 0; i < ImageDimension - 1; i++)
+  {
+    if (!DICOMOrientation::SameOrientationAxes(given_codes[i], desired_codes[i]))
+    {
+      for (unsigned int j = 0; j < ImageDimension; j++)
+      {
+        if (DICOMOrientation::SameOrientationAxes(given_codes[i], desired_codes[j]))
+        {
+          if (i == j)
+          {
+            // Axis i is already in place
+            continue;
+          }
+          if (DICOMOrientation::SameOrientationAxes(given_codes[j], desired_codes[i]))
+          {
+            // The cyclic permutation (i j) applies. Therefore the remainder
+            // is (k), i.e., stationary
+            m_PermuteOrder[i] = j;
+            m_PermuteOrder[j] = i;
+          }
+          else
+          {
+            // work out an (i j k) cyclic permutation
+            for (unsigned int k = 0; k < ImageDimension; k++)
+            {
+
+              if (DICOMOrientation::SameOrientationAxes(given_codes[j], desired_codes[k]))
+              {
+                // At this point, we can pick off (i j k)
+                m_PermuteOrder[i] = k;
+                m_PermuteOrder[j] = i;
+                m_PermuteOrder[k] = j;
+                break;
+              }
+            }
+            // Effectively, if (k==3) continue
+          }
+          break;
+        }
+      }
+      // Effectively, if (j==3) continue
+    }
+  }
+
+  for (unsigned int i = 0; i < ImageDimension; i++)
+  {
+    const unsigned int j = m_PermuteOrder[i];
+    if ((static_cast<uint8_t>(given_codes[j]) & CodeAxisDir) != (static_cast<uint8_t>(desired_codes[i]) & CodeAxisDir))
+    {
+      m_FlipAxes[i] = true;
+    }
+  }
+}
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::SetInputCoordinateOrientation(OrientationEnum newCode)
+{
+  m_InputCoordinateOrientation = newCode;
+
+  this->DeterminePermutationsAndFlips(m_DesiredCoordinateOrientation, m_InputCoordinateOrientation);
+}
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::SetDesiredCoordinateOrientation(OrientationEnum newCode)
+{
+  if (m_DesiredCoordinateOrientation != newCode)
+  {
+    m_DesiredCoordinateOrientation = newCode;
+    this->DeterminePermutationsAndFlips(m_DesiredCoordinateOrientation, m_InputCoordinateOrientation);
+    this->Modified();
+  }
+}
+
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::SetDesiredCoordinateOrientation(const std::string & desired)
+{
+  DICOMOrientation o(desired);
+
+  if (OrientationEnum(o) == OrientationEnum::INVALID)
+  {
+    itkWarningMacro("Invalid desired coordinate direction string: \"" << desired << "\"!");
+  }
+  this->SetDesiredCoordinateOrientation(o);
+}
+
+template <typename TInputImage>
+bool
+DICOMOrientImageFilter<TInputImage>::NeedToPermute()
+{
+  for (unsigned int j = 0; j < ImageDimension; j++)
+  {
+    if (m_PermuteOrder[j] != j)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename TInputImage>
+bool
+DICOMOrientImageFilter<TInputImage>::NeedToFlip()
+{
+  for (unsigned int j = 0; j < ImageDimension; j++)
+  {
+    if (m_FlipAxes[j])
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::GenerateData()
+{
+  // Create a process accumulator for tracking the progress of this minipipeline
+  typename ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
+  progress->SetMiniPipelineFilter(this);
+
+  // No need to allocate the output since the minipipeline does it
+  // this->AllocateOutputs();
+
+  using PermuteFilterType = PermuteAxesImageFilter<ImageType>;
+  using FlipFilterType = FlipImageFilter<ImageType>;
+  using CastToOutputFilterType = CastImageFilter<ImageType, ImageType>;
+
+  typename PermuteFilterType::Pointer      permute = PermuteFilterType::New();
+  typename FlipFilterType::Pointer         flip = FlipFilterType::New();
+  typename CastToOutputFilterType::Pointer cast = CastToOutputFilterType::New();
+
+  progress->RegisterInternalFilter(permute, .45f);
+  progress->RegisterInternalFilter(flip, .45);
+  progress->RegisterInternalFilter(cast, .1f);
+
+  typename ImageType::Pointer inputPtr = ImageType::New();
+  inputPtr->Graft(const_cast<ImageType *>(this->GetInput()));
+
+  typename ImageType::Pointer nextInput = inputPtr;
+
+  // Only run those filters that will do something
+  if (NeedToPermute())
+  {
+    permute->SetInput(nextInput);
+    permute->SetOrder(m_PermuteOrder);
+    permute->ReleaseDataFlagOn();
+    nextInput = permute->GetOutput();
+  }
+  else
+  {
+    itkDebugMacro("No need to permute");
+  }
+  if (NeedToFlip())
+  {
+    flip->SetInput(nextInput);
+    flip->SetFlipAxes(m_FlipAxes);
+    flip->FlipAboutOriginOff();
+    nextInput = flip->GetOutput();
+  }
+  else
+  {
+    itkDebugMacro(<< "No need to flip");
+  }
+
+  //
+  // Cast might not be necessary, but CastImagefilter is optimized for
+  // the case where the ImageType == OutputImageType
+  cast->SetInput(nextInput);
+  cast->GraftOutput(this->GetOutput());
+  cast->Update();
+
+  this->GraftOutput(cast->GetOutput());
+}
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::GenerateOutputInformation()
+{
+  // Call the superclass' implementation of this method
+  Superclass::GenerateOutputInformation();
+
+  // Get pointers to the input and output
+
+  typename ImageType::Pointer inputPtr = ImageType::New();
+  inputPtr->Graft(const_cast<ImageType *>(this->GetInput()));
+  ImageType * outputPtr = this->GetOutput();
+
+
+  // Compute the GivenOrientation from the image's direction cosines
+  const DICOMOrientation inputOrientation(inputPtr->GetDirection());
+  this->SetInputCoordinateOrientation(inputOrientation.GetAsOrientation());
+
+  using PermuteFilterType = PermuteAxesImageFilter<ImageType>;
+  using FlipFilterType = FlipImageFilter<ImageType>;
+
+  typename PermuteFilterType::Pointer permute = PermuteFilterType::New();
+  typename FlipFilterType::Pointer    flip = FlipFilterType::New();
+  permute->SetInput(inputPtr);
+  permute->SetOrder(m_PermuteOrder);
+
+  flip->SetInput(permute->GetOutput());
+  flip->SetFlipAxes(m_FlipAxes);
+  flip->FlipAboutOriginOff();
+
+  flip->GraftOutput(this->GetOutput());
+  flip->UpdateOutputInformation();
+
+  outputPtr->CopyInformation(flip->GetOutput());
+}
+
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  Superclass::VerifyPreconditions();
+
+  if (this->m_DesiredCoordinateOrientation == OrientationEnum::INVALID)
+  {
+    itkExceptionMacro(<< "DesiredCoordinateOrientation is 'INVALID'.");
+  }
+}
+
+template <typename TInputImage>
+void
+DICOMOrientImageFilter<TInputImage>::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+
+  os << indent << "Desired Coordinate Orientation: " << static_cast<long>(this->GetDesiredCoordinateOrientation())
+     << " (" << this->GetDesiredCoordinateOrientation() << ")" << std::endl;
+  os << indent << "Input Coordinate Orientation: " << static_cast<long>(this->GetInputCoordinateOrientation()) << " ("
+     << this->GetInputCoordinateOrientation() << ")" << std::endl;
+  os << indent << "Permute Axes: " << m_PermuteOrder << std::endl;
+  os << indent << "Flip Axes: " << m_FlipAxes << std::endl;
+}
+} // end namespace itk
+#endif

--- a/Core/itkDICOMOrientation.cxx
+++ b/Core/itkDICOMOrientation.cxx
@@ -1,0 +1,279 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "Precompiled.h"
+
+#include "itkDICOMOrientation.h"
+
+// Needed for itk::Function::Max3
+#include "itkSpatialOrientationAdapter.h"
+
+
+namespace itk
+{
+
+
+DICOMOrientation::DICOMOrientation(CoordinateEnum primary, CoordinateEnum secondary, CoordinateEnum tertiary)
+{
+  if (SameOrientationAxes(primary, secondary) || SameOrientationAxes(primary, tertiary) ||
+      SameOrientationAxes(secondary, tertiary))
+  {
+    m_Value = OrientationEnum::INVALID;
+  }
+  else
+  {
+    m_Value = static_cast<OrientationEnum>(toOrientation(primary, secondary, tertiary));
+  }
+}
+
+DICOMOrientation::DICOMOrientation(std::string str)
+  : m_Value(OrientationEnum::INVALID)
+{
+  std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+  const std::map<std::string, typename DICOMOrientation::OrientationEnum> & stringToCode = GetStringToCode();
+  auto                                                                      iter = stringToCode.find(str);
+  if (iter != stringToCode.end())
+  {
+    m_Value = iter->second;
+  }
+}
+
+
+const std::string &
+DICOMOrientation::GetAsString() const
+{
+  const auto & codeToString = GetCodeToString();
+  auto         iter = codeToString.find(m_Value);
+  if (iter != codeToString.end())
+  {
+    return iter->second;
+  }
+  assert(codeToString.find(OrientationEnum::INVALID) != codeToString.end());
+  return codeToString.find(OrientationEnum::INVALID)->second;
+}
+
+
+DICOMOrientation::CoordinateEnum
+DICOMOrientation::GetCoordinateTerm(CoordinateMajornessTermsEnum cmt) const
+{
+  return static_cast<CoordinateEnum>(static_cast<uint32_t>(m_Value) >> static_cast<uint8_t>(cmt) & 0xff);
+}
+
+std::map<std::string, typename DICOMOrientation::OrientationEnum>
+DICOMOrientation::CreateStringToCode()
+{
+  std::map<std::string, OrientationEnum>         stringToCode;
+  const std::map<OrientationEnum, std::string> & codeToString = GetCodeToString();
+
+  for (const auto & kv : codeToString)
+  {
+    stringToCode[kv.second] = kv.first;
+  }
+  return stringToCode;
+}
+
+
+const std::map<typename DICOMOrientation::OrientationEnum, std::string> &
+DICOMOrientation::GetCodeToString()
+{
+  static const std::map<OrientationEnum, std::string> codeToString = CreateCodeToString();
+  return codeToString;
+}
+
+const std::map<std::string, DICOMOrientation::OrientationEnum> &
+DICOMOrientation::GetStringToCode()
+{
+  static const std::map<std::string, DICOMOrientation::OrientationEnum> stringToCode = CreateStringToCode();
+  return stringToCode;
+}
+
+
+std::map<typename DICOMOrientation::OrientationEnum, std::string>
+DICOMOrientation::CreateCodeToString()
+{
+  std::map<OrientationEnum, std::string> orientToString;
+  auto                                   helperAddCode = [&orientToString](std::string str, OrientationEnum code) {
+    orientToString[code] = std::move(str);
+  };
+
+  // Map between axis string labels and SpatialOrientation
+  helperAddCode("RIP", OrientationEnum::RIP);
+  helperAddCode("LIP", OrientationEnum::LIP);
+  helperAddCode("RSP", OrientationEnum::RSP);
+  helperAddCode("LSP", OrientationEnum::LSP);
+  helperAddCode("RIA", OrientationEnum::RIA);
+  helperAddCode("LIA", OrientationEnum::LIA);
+  helperAddCode("RSA", OrientationEnum::RSA);
+  helperAddCode("LSA", OrientationEnum::LSA);
+  helperAddCode("IRP", OrientationEnum::IRP);
+  helperAddCode("ILP", OrientationEnum::ILP);
+  helperAddCode("SRP", OrientationEnum::SRP);
+  helperAddCode("SLP", OrientationEnum::SLP);
+  helperAddCode("IRA", OrientationEnum::IRA);
+  helperAddCode("ILA", OrientationEnum::ILA);
+  helperAddCode("SRA", OrientationEnum::SRA);
+  helperAddCode("SLA", OrientationEnum::SLA);
+  helperAddCode("RPI", OrientationEnum::RPI);
+  helperAddCode("LPI", OrientationEnum::LPI);
+  helperAddCode("RAI", OrientationEnum::RAI);
+  helperAddCode("LAI", OrientationEnum::LAI);
+  helperAddCode("RPS", OrientationEnum::RPS);
+  helperAddCode("LPS", OrientationEnum::LPS);
+  helperAddCode("RAS", OrientationEnum::RAS);
+  helperAddCode("LAS", OrientationEnum::LAS);
+  helperAddCode("PRI", OrientationEnum::PRI);
+  helperAddCode("PLI", OrientationEnum::PLI);
+  helperAddCode("ARI", OrientationEnum::ARI);
+  helperAddCode("ALI", OrientationEnum::ALI);
+  helperAddCode("PRS", OrientationEnum::PRS);
+  helperAddCode("PLS", OrientationEnum::PLS);
+  helperAddCode("ARS", OrientationEnum::ARS);
+  helperAddCode("ALS", OrientationEnum::ALS);
+  helperAddCode("IPR", OrientationEnum::IPR);
+  helperAddCode("SPR", OrientationEnum::SPR);
+  helperAddCode("IAR", OrientationEnum::IAR);
+  helperAddCode("SAR", OrientationEnum::SAR);
+  helperAddCode("IPL", OrientationEnum::IPL);
+  helperAddCode("SPL", OrientationEnum::SPL);
+  helperAddCode("IAL", OrientationEnum::IAL);
+  helperAddCode("SAL", OrientationEnum::SAL);
+  helperAddCode("PIR", OrientationEnum::PIR);
+  helperAddCode("PSR", OrientationEnum::PSR);
+  helperAddCode("AIR", OrientationEnum::AIR);
+  helperAddCode("ASR", OrientationEnum::ASR);
+  helperAddCode("PIL", OrientationEnum::PIL);
+  helperAddCode("PSL", OrientationEnum::PSL);
+  helperAddCode("AIL", OrientationEnum::AIL);
+  helperAddCode("ASL", OrientationEnum::ASL);
+  helperAddCode("INVALID", OrientationEnum::INVALID);
+
+  return orientToString;
+}
+
+
+typename DICOMOrientation::OrientationEnum
+DICOMOrientation::DirectionCosinesToOrientation(const DirectionType & dir)
+{
+  // NOTE: This method was based off of itk::SpatialObjectAdaptor::FromDirectionCosines
+  // but it is DIFFERENT in the meaning of direction in terms of sign-ness.
+  CoordinateEnum terms[3] = { CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN, CoordinateEnum::UNKNOWN };
+
+  std::multimap< double, std::pair<unsigned, unsigned> > value_to_idx;
+  for (unsigned int c = 0; c < 3; ++c )
+    {
+    for (unsigned int r = 0; r < 3; ++r )
+      {
+      value_to_idx.emplace(std::abs(dir[c][r]), std::make_pair(c,r));
+      }
+    }
+
+  for (unsigned i = 0; i < 3; ++i)
+    {
+
+    auto max_idx = value_to_idx.rbegin()->second;
+    const unsigned int max_c = max_idx.first;
+    const unsigned int max_r = max_idx.second;
+
+    const int max_sgn = Math::sgn(dir[max_c][max_r]);
+
+    for (auto it = value_to_idx.begin(); it != value_to_idx.end();)
+    {
+    if (it->second.first == max_c || it->second.second == max_r)
+      {
+      value_to_idx.erase(it++);
+      }
+    else
+      {
+      ++it;
+      }
+    }
+
+    switch (max_c)
+    {
+      case 0: {
+        // When the dominant axis sign is positive, assign the coordinate for the direction we are increasing towards.
+        // ITK is in LPS, so that is the positive direction
+        terms[max_r] = (max_sgn == 1) ? CoordinateEnum::Left : CoordinateEnum::Right;
+        break;
+      }
+      case 1: {
+        terms[max_r] = (max_sgn == 1) ? CoordinateEnum::Posterior : CoordinateEnum::Anterior;
+        break;
+      }
+      case 2: {
+        terms[max_r] = (max_sgn == 1) ? CoordinateEnum::Superior : CoordinateEnum::Inferior;
+        break;
+      }
+      default:
+        itkGenericExceptionMacro("Unexpected Axis");
+    }
+  }
+
+  return static_cast<OrientationEnum>(toOrientation(terms[0], terms[1], terms[2]));
+}
+
+
+typename DICOMOrientation::DirectionType
+DICOMOrientation::OrientationToDirectionCosines(OrientationEnum orientationEnum)
+{
+  const DICOMOrientation o(orientationEnum);
+
+  CoordinateEnum terms[Dimension] = { o.GetPrimaryTerm(), o.GetSecondaryTerm(), o.GetTertiaryTerm() };
+  DirectionType  direction;
+  direction.Fill(0.0);
+
+  for (unsigned int i = 0; i < Dimension; ++i)
+  {
+    const int sign = (static_cast<uint8_t>(terms[i]) & 0x1) ? 1 : -1;
+
+    switch (terms[i])
+    {
+      case CoordinateEnum::Left:
+      case CoordinateEnum::Right:
+        direction[0][i] = 1 * sign;
+        break;
+      case CoordinateEnum::Anterior:
+      case CoordinateEnum::Posterior:
+        direction[1][i] = 1 * sign;
+        break;
+      case CoordinateEnum::Inferior:
+      case CoordinateEnum::Superior:
+        direction[2][i] = 1 * sign;
+        break;
+      case CoordinateEnum::UNKNOWN:
+        break;
+    }
+  }
+  return direction;
+}
+
+std::ostream &
+operator<<(std::ostream & out, typename DICOMOrientation::OrientationEnum value)
+{
+  auto iter = DICOMOrientation::GetCodeToString().find(value);
+  assert(iter != DICOMOrientation::GetCodeToString().end());
+  return (out << iter->second);
+}
+
+
+std::ostream &
+operator<<(std::ostream & out, const DICOMOrientation & orientation)
+{
+  return (out << orientation.GetAsString());
+}
+
+} // namespace itk

--- a/Core/itkDICOMOrientation.h
+++ b/Core/itkDICOMOrientation.h
@@ -1,0 +1,255 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkDICOMOrientation_h
+#define itkDICOMOrientation_h
+
+#include "iSegCore.h"
+#define SimpleITKFilters_EXPORT ISEG_CORE_API
+
+#include "itkImageBase.h"
+
+#include <map>
+#include <string>
+
+namespace itk
+{
+
+/** \class DICOMOrientation
+ * \brief A supporting class for DICOMOrientImageFilter.
+ *
+ *  Defines enums to for patient orientation in a compatible way with DICOM.
+ *
+ *  Instances hold the patient orientation enum and allow conversion to and from enums, string and direction cosine
+ * matrices. Conversions from a direction cosine matrix is approximated with the orientation of the closes axes.
+ *
+ * \ingroup SimpleITKFilters
+ */
+class SimpleITKFilters_EXPORT  DICOMOrientation
+{
+public:
+  constexpr static unsigned int Dimension = 3;
+  using DirectionType = typename ImageBase<Dimension>::DirectionType;
+  constexpr static unsigned int ImageDimension = Dimension;
+
+
+  enum class CoordinateEnum : uint8_t
+  {
+    UNKNOWN = 0,
+    Right = 2, // 0b0010
+    Left = 3,
+    Anterior = 4,  ///< front - 0b0100
+    Posterior = 5, ///< back
+    Inferior = 8,  ///< bottom - 0b1000
+    Superior = 9   ///< above
+  };
+
+private:
+  enum class CoordinateMajornessTermsEnum : uint8_t
+  {
+    PrimaryMinor = 0,
+    SecondaryMinor = 8,
+    TertiaryMinor = 16
+  };
+
+  constexpr static uint32_t
+  toOrientation(const CoordinateEnum primary, const CoordinateEnum secondary, const CoordinateEnum tertiary)
+  {
+    return (static_cast<uint32_t>(primary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::PrimaryMinor)) +
+           (static_cast<uint32_t>(secondary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::SecondaryMinor)) +
+           (static_cast<uint32_t>(tertiary) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::TertiaryMinor));
+  }
+
+public:
+#if 0
+#  define ITK_ORIENTATIONENUM toOrientation
+#else
+
+#  define ITK_ORIENTATIONENUM(P, S, T)                                                                                 \
+    (static_cast<uint32_t>(P) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::PrimaryMinor)) +                   \
+      (static_cast<uint32_t>(S) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::SecondaryMinor)) +               \
+      (static_cast<uint32_t>(T) << static_cast<uint8_t>(CoordinateMajornessTermsEnum::TertiaryMinor))
+
+#endif
+
+  enum class OrientationEnum : uint32_t
+
+  {
+    INVALID = 0,
+    RIP = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Inferior, CoordinateEnum::Posterior),
+    LIP = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Inferior, CoordinateEnum::Posterior),
+    RSP = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Superior, CoordinateEnum::Posterior),
+    LSP = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Superior, CoordinateEnum::Posterior),
+    RIA = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Inferior, CoordinateEnum::Anterior),
+    LIA = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Inferior, CoordinateEnum::Anterior),
+    RSA = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Superior, CoordinateEnum::Anterior),
+    LSA = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Superior, CoordinateEnum::Anterior),
+
+    IRP = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Right, CoordinateEnum::Posterior),
+    ILP = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Left, CoordinateEnum::Posterior),
+    SRP = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Right, CoordinateEnum::Posterior),
+    SLP = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Left, CoordinateEnum::Posterior),
+    IRA = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Right, CoordinateEnum::Anterior),
+    ILA = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Left, CoordinateEnum::Anterior),
+    SRA = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Right, CoordinateEnum::Anterior),
+    SLA = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Left, CoordinateEnum::Anterior),
+
+    RPI = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Posterior, CoordinateEnum::Inferior),
+    LPI = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Posterior, CoordinateEnum::Inferior),
+    RAI = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Anterior, CoordinateEnum::Inferior),
+    LAI = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Anterior, CoordinateEnum::Inferior),
+    RPS = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Posterior, CoordinateEnum::Superior),
+    LPS = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Posterior, CoordinateEnum::Superior),
+    RAS = ITK_ORIENTATIONENUM(CoordinateEnum::Right, CoordinateEnum::Anterior, CoordinateEnum::Superior),
+    LAS = ITK_ORIENTATIONENUM(CoordinateEnum::Left, CoordinateEnum::Anterior, CoordinateEnum::Superior),
+
+    PRI = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Right, CoordinateEnum::Inferior),
+    PLI = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Left, CoordinateEnum::Inferior),
+    ARI = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Right, CoordinateEnum::Inferior),
+    ALI = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Left, CoordinateEnum::Inferior),
+    PRS = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Right, CoordinateEnum::Superior),
+    PLS = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Left, CoordinateEnum::Superior),
+    ARS = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Right, CoordinateEnum::Superior),
+    ALS = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Left, CoordinateEnum::Superior),
+
+    IPR = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Posterior, CoordinateEnum::Right),
+    SPR = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Posterior, CoordinateEnum::Right),
+    IAR = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Anterior, CoordinateEnum::Right),
+    SAR = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Anterior, CoordinateEnum::Right),
+    IPL = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Posterior, CoordinateEnum::Left),
+    SPL = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Posterior, CoordinateEnum::Left),
+    IAL = ITK_ORIENTATIONENUM(CoordinateEnum::Inferior, CoordinateEnum::Anterior, CoordinateEnum::Left),
+    SAL = ITK_ORIENTATIONENUM(CoordinateEnum::Superior, CoordinateEnum::Anterior, CoordinateEnum::Left),
+
+    PIR = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Inferior, CoordinateEnum::Right),
+    PSR = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Superior, CoordinateEnum::Right),
+    AIR = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Inferior, CoordinateEnum::Right),
+    ASR = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Superior, CoordinateEnum::Right),
+    PIL = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Inferior, CoordinateEnum::Left),
+    PSL = ITK_ORIENTATIONENUM(CoordinateEnum::Posterior, CoordinateEnum::Superior, CoordinateEnum::Left),
+    AIL = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Inferior, CoordinateEnum::Left),
+    ASL = ITK_ORIENTATIONENUM(CoordinateEnum::Anterior, CoordinateEnum::Superior, CoordinateEnum::Left)
+  };
+
+#undef ITK_ORIENTATIONENUM
+
+
+  /** \brief Initialize with CoordinateEnum's from separate axes.
+   *
+   * If multiple CorrdinateEnums are from the same axes then the Orientation value is INVALID.
+   */
+  DICOMOrientation(CoordinateEnum primary, CoordinateEnum secondary, CoordinateEnum tertiary);
+
+  DICOMOrientation(OrientationEnum orientation)
+    : m_Value(orientation)
+  {}
+
+  explicit DICOMOrientation(const DirectionType & d)
+    : m_Value(DirectionCosinesToOrientation(d))
+  {}
+
+  explicit DICOMOrientation(std::string str);
+
+  operator OrientationEnum() const { return m_Value; }
+
+  const std::string &
+  GetAsString() const;
+
+  DirectionType
+  GetAsDirection() const
+  {
+    return OrientationToDirectionCosines(m_Value);
+  }
+
+  OrientationEnum
+  GetAsOrientation() const
+  {
+    return m_Value;
+  }
+
+  CoordinateEnum
+  GetCoordinateTerm(CoordinateMajornessTermsEnum cmt) const;
+
+  CoordinateEnum
+  GetPrimaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::PrimaryMinor);
+  }
+
+  CoordinateEnum
+  GetSecondaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::SecondaryMinor);
+  }
+
+  CoordinateEnum
+  GetTertiaryTerm() const
+  {
+    return GetCoordinateTerm(CoordinateMajornessTermsEnum::TertiaryMinor);
+  }
+
+
+  static bool
+  SameOrientationAxes(CoordinateEnum a, CoordinateEnum b)
+  {
+    const unsigned int AxisField = 0xE; // b1110, mask lowest bit
+    return (static_cast<uint8_t>(a) & AxisField) == (static_cast<uint8_t>(b) & AxisField);
+  }
+
+  /** \brief Return the closest orientation for a direction cosine matrix. */
+  static OrientationEnum
+  DirectionCosinesToOrientation(const DirectionType & dir);
+
+  /** \brief Return the direction cosine matrix for a orientation. */
+  static DirectionType OrientationToDirectionCosines(OrientationEnum);
+
+
+  friend SimpleITKFilters_EXPORT  std::ostream & operator<<(std::ostream & out, OrientationEnum value);
+
+
+private:
+  // Private methods to create the maps, these will only be called once.
+  static std::map<OrientationEnum, std::string>
+  CreateCodeToString();
+  static std::map<std::string, OrientationEnum>
+  CreateStringToCode();
+
+  /** \brief Return the global instance of the map from orientation enum to strings.
+   *
+   * The implementation uses a function static local variable so the global is created only if needed, only once.
+   */
+  static const std::map<OrientationEnum, std::string> &
+  GetCodeToString();
+
+  /** \brief Return the global instance of the map from string to orientation enum.
+   */
+  static const std::map<std::string, OrientationEnum> &
+  GetStringToCode();
+
+  OrientationEnum m_Value;
+};
+
+
+SimpleITKFilters_EXPORT  std::ostream & operator<<(std::ostream & out, typename DICOMOrientation::OrientationEnum value);
+
+SimpleITKFilters_EXPORT  std::ostream & operator<<(std::ostream & out, const DICOMOrientation & orientation);
+
+
+} // end namespace itk
+
+
+#endif

--- a/Data/CMakeLists.txt
+++ b/Data/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(SOURCES
 	LogApi.cpp
 	Property.cpp
 	SlicesHandlerITKInterface.cpp
+	TimeStamp.cpp
 	Transform.cpp
 )
 

--- a/Data/SlicesHandlerInterface.h
+++ b/Data/SlicesHandlerInterface.h
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include "TimeStamp.h"
 #include "Transform.h"
 #include "Types.h"
 
@@ -56,6 +57,16 @@ public:
 	virtual void GetColor(size_t, unsigned char& r, unsigned char& g, unsigned char& b) const = 0;
 
 	virtual void SetTargetFixedRange(bool on) = 0;
+
+	virtual bool ReadVolume(const std::string& file_path, bool tissue) { return false; }
+	virtual void SignalVolumeChange(bool update_tissues) {}
+
+	void Modified() { m_ModifyTime.Modified(); }
+
+	const TimeStamp& ModifyTime() const { return m_ModifyTime; }
+
+private:
+	TimeStamp m_ModifyTime;
 };
 
 } // namespace iseg

--- a/Data/TimeStamp.cpp
+++ b/Data/TimeStamp.cpp
@@ -1,0 +1,13 @@
+#include "TimeStamp.h"
+
+#include <atomic>
+
+namespace iseg {
+
+void TimeStamp::Modified()
+{
+	static std::atomic<modify_time_t> id{0};
+	this->m_ModifiedTime = id.fetch_add(1, std::memory_order_relaxed) + 1;
+}
+
+} // namespace iseg

--- a/Data/TimeStamp.h
+++ b/Data/TimeStamp.h
@@ -29,12 +29,12 @@ public:
 		return m_ModifiedTime;
 	}
 
-	bool operator>(TimeStamp& ts) const
+	bool operator>(const TimeStamp& ts) const
 	{
 		return (m_ModifiedTime > ts.m_ModifiedTime);
 	}
 
-	bool operator<(TimeStamp& ts) const
+	bool operator<(const TimeStamp& ts) const
 	{
 		return (m_ModifiedTime < ts.m_ModifiedTime);
 	}

--- a/Data/TimeStamp.h
+++ b/Data/TimeStamp.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018 The Foundation for Research on Information Technologies in
+ Society (IT'IS).
+ *
+ * This file is part of iSEG
+ * (see https://github.com/ITISFoundation/osparc-iseg).
+ *
+ * This software is released under the MIT License.
+ *  https://opensource.org/licenses/MIT
+ */
+
+#pragma once
+
+#include "iSegData.h"
+
+#include <cstdint>
+
+namespace iseg {
+
+class ISEG_DATA_API TimeStamp
+{
+public:
+	using modify_time_t = std::uint64_t;
+
+	void Modified();
+
+	modify_time_t GetMTime() const
+	{
+		return m_ModifiedTime;
+	}
+
+	bool operator>(TimeStamp& ts) const
+	{
+		return (m_ModifiedTime > ts.m_ModifiedTime);
+	}
+
+	bool operator<(TimeStamp& ts) const
+	{
+		return (m_ModifiedTime < ts.m_ModifiedTime);
+	}
+
+	operator modify_time_t() const { return m_ModifiedTime; }
+
+private:
+	modify_time_t m_ModifiedTime{0};
+};
+
+} // namespace iseg

--- a/Data/Transform.cpp
+++ b/Data/Transform.cpp
@@ -70,4 +70,19 @@ bool Transform::operator!=(const Transform& other) const
 	return false;
 }
 
+bool Transform::HasFlip() const
+{
+	// determinant of rotation matrix is negative
+	float det = m_M[0][0] * (m_M[1][1] * m_M[2][2] - m_M[1][2] * m_M[2][1]) - m_M[0][1] * (m_M[1][0] * m_M[2][2] - m_M[1][2] * m_M[2][0]) + m_M[0][2] * (m_M[1][0] * m_M[2][1] - m_M[1][1] * m_M[2][0]);
+
+	return det < 0.0;
+}
+
+std::vector<double> Transform::ToVector() const
+{
+	auto& self = *this;
+	auto begin = static_cast<const float*>(self[0]);
+	return std::vector<double>(begin, begin + 16);
+}
+
 } // namespace iseg

--- a/Data/Transform.h
+++ b/Data/Transform.h
@@ -14,6 +14,7 @@
 #include "iSegData.h"
 
 #include <algorithm>
+#include <vector>
 
 namespace iseg {
 
@@ -66,10 +67,14 @@ public:
 	// for cropping, padding_lo[.] is negative
 	void PaddingUpdateTransform(const int padding_lo[3], const Vec3& spacing);
 
+	bool HasFlip() const;
+
 	float* operator[](size_t row) { return m_M[row]; }
 	const float* operator[](size_t row) const { return m_M[row]; }
 
 	bool operator!=(const Transform& other) const;
+
+	std::vector<double> ToVector() const;
 };
 
 template<typename TVec3>

--- a/iSeg/CMakeLists.txt
+++ b/iSeg/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(ViewerSrcs
 	bmp_read_1.cpp
 	ImageViewerWidget.cpp
 	ChannelExtractor.cpp
+	DataIteratorWidget.cpp
 	DicomReader.cpp
 	EdgeWidget.cpp
 	FastmarchingFuzzyWidget.cpp
@@ -97,6 +98,7 @@ SET(MyMocHeaders
 	ActiveSlicesConfigDialog.h
 	AtlasViewer.h
 	AtlasWidget.h
+	DataIteratorWidget.h
 	EdgeWidget.h
 	FastmarchingFuzzyWidget.h
 	FeatureWidget.h

--- a/iSeg/DataIteratorWidget.cpp
+++ b/iSeg/DataIteratorWidget.cpp
@@ -46,7 +46,7 @@ struct Orientation
 	eOrientation tag;
 };
 
-const std::array<Orientation, 4> _OrientationNames = {
+const std::array<Orientation, 4> kOrientationNames = {
 		Orientation{"no change", eOrientation::noChange},
 		Orientation{"Axial", eOrientation::RAS},
 		Orientation{"Sagittal", eOrientation::PSL},
@@ -113,7 +113,7 @@ DataIteratorWidget::DataIteratorWidget(iseg::SlicesHandler* hand3D, QWidget* par
 	m_LoadProcessed->setToolTip("Load labels from 'Processed Output' if it exists.");
 
 	m_Orientation = new QComboBox;
-	for (auto& o : _OrientationNames)
+	for (auto& o : kOrientationNames)
 	{
 		m_Orientation->addItem(QString::fromStdString(o.name));
 	}
@@ -252,7 +252,7 @@ void DataIteratorWidget::Load(int pair_idx)
 		}
 
 		//
-		const auto orientation = static_cast<int>(_OrientationNames.at(m_Orientation->currentIndex()).tag);
+		const auto orientation = static_cast<int>(kOrientationNames.at(m_Orientation->currentIndex()).tag);
 
 		iseg::DataSelection dataSelection;
 		dataSelection.allSlices = true;
@@ -263,17 +263,25 @@ void DataIteratorWidget::Load(int pair_idx)
 
 		// read labels
 		const auto load_processed = m_LoadProcessed->isChecked() && fs::exists(processed_path, ec);
-		m_Handler3D->ReadVolumeOrient(load_processed ? processed_path.string() : labels_path, true, orientation);
+		if (!m_Handler3D->ReadVolumeOrient(load_processed ? processed_path.string() : labels_path, true, orientation))
+		{
+			ISEG_WARNING("Failed to read labels");
+		}
 
 		// read target
 		if (!m_TargetDir->text().isEmpty() && fs::exists(target_path, ec))
 		{
-			m_Handler3D->ReadVolumeOrient(target_path.string(), false, orientation);
-			m_Handler3D->Bmp2workall();
+			if (m_Handler3D->ReadVolumeOrient(target_path.string(), false, orientation))
+			{
+				m_Handler3D->Bmp2workall();
+			}
 		}
 
 		// read image
-		m_Handler3D->ReadVolumeOrient(image_path, false, orientation);
+		if (!m_Handler3D->ReadVolumeOrient(image_path, false, orientation))
+		{
+			ISEG_WARNING("Failed to read image");
+		}
 
 		emit EndDatachange(this, iseg::ClearUndo);
 
@@ -337,7 +345,7 @@ void DataIteratorWidget::Save()
 
 		tissue_image_t::Pointer tissues = itk_handler.GetTissuesDeprecated(false);
 
-		const auto orientation = _OrientationNames.at(m_Orientation->currentIndex()).tag;
+		const auto orientation = kOrientationNames.at(m_Orientation->currentIndex()).tag;
 		if (orientation != eOrientation::noChange)
 		{
 			// load input orientation

--- a/iSeg/DataIteratorWidget.cpp
+++ b/iSeg/DataIteratorWidget.cpp
@@ -103,7 +103,7 @@ DataIteratorWidget::DataIteratorWidget(iseg::SlicesHandler* hand3D, QWidget* par
 	m_SaveButton = new QPushButton("Save");
 	m_SaveButton->setToolTip("Save local changes to the labels to the 'Processed Output' folder.");
 	m_SaveMarksButton = new QPushButton("Save Marks");
-	m_SaveMarksButton->setToolTip("Save local changes to the labels to the 'Processed Output' folder.");
+	m_SaveMarksButton->setToolTip("Save marks/landmarks to the 'Processed Output' folder.");
 	m_NextButton = new QPushButton("Next");
 	m_NextButton->setToolTip("Load next image/label pair.");
 	m_NextUnprocessedButton = new QPushButton("Next Unprocessed");
@@ -153,7 +153,13 @@ void DataIteratorWidget::LoadNext(bool skip_processed)
 		m_FileTime.Modified();
 		current_pair = -1;
 
-		fs::directory_iterator dir_itr(m_CachedImageDir);
+		boost::system::error_code dir_ec;
+		fs::directory_iterator dir_itr(m_CachedImageDir, dir_ec);
+		if (dir_ec)
+		{
+			m_Status->setText(QString("[0/0] Cannot open directory: %1").arg(QString::fromStdString(m_CachedImageDir)));
+			return;
+		}
 		fs::directory_iterator end_iter;
 		for (; dir_itr != end_iter; ++dir_itr)
 		{
@@ -197,10 +203,7 @@ void DataIteratorWidget::LoadNext(bool skip_processed)
 				current_pair++;
 			}
 		}
-	}
 
-	if (current_pair < static_cast<int>(m_ImageLabelPairs.size()))
-	{
 		Load(current_pair);
 	}
 	else
@@ -231,7 +234,7 @@ void DataIteratorWidget::Load(int pair_idx)
 		}
 	}
 
-	if (pair_idx < static_cast<int>(m_ImageLabelPairs.size()))
+	if (pair_idx >= 0 && pair_idx < static_cast<int>(m_ImageLabelPairs.size()))
 	{
 		const auto image_path = m_ImageLabelPairs[pair_idx].first;
 		const auto labels_path = m_ImageLabelPairs[pair_idx].second;
@@ -315,7 +318,8 @@ void DataIteratorWidget::Save()
 		const fs::path image_path(m_ImageLabelPairs[m_CurrentPair].first);
 		const fs::path output_file_path = output_dir / image_path.filename();
 
-		if (!m_LoadProcessed->isChecked() && fs::exists(output_file_path))
+		boost::system::error_code ec2;
+		if (!m_LoadProcessed->isChecked() && fs::exists(output_file_path, ec2))
 		{
 			const int ret = QMessageBox::warning(
 					this, "iSeg", "The output file exists. Do you want to overwrite it with your changes?",

--- a/iSeg/DataIteratorWidget.cpp
+++ b/iSeg/DataIteratorWidget.cpp
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) 2018 The Foundation for Research on Information Technologies in
+ Society (IT'IS).
+ *
+ * This file is part of iSEG
+ * (see https://github.com/ITISFoundation/osparc-iseg).
+ *
+ * This software is released under the MIT License.
+ *  https://opensource.org/licenses/MIT
+ */
+#include "Precompiled.h"
+
+#include "DataIteratorWidget.h"
+#include "SlicesHandler.h"
+
+#include "../Interface/FormatTooltip.h"
+#include "../Interface/LayoutTools.h"
+
+#include "../Core/ImageReader.h"
+#include "../Core/itkDICOMOrientImageFilter.h"
+
+#include "../Data/ItkUtils.h"
+#include "../Data/SlicesHandlerITKInterface.h"
+
+#include <itkImageFileReader.h>
+
+#include <QCompleter>
+#include <QFileSystemModel>
+#include <QFormLayout>
+#include <QMessageBox>
+
+#include <boost/filesystem.hpp>
+
+#include <algorithm>
+#include <sstream>
+#include <utility>
+
+namespace iseg {
+
+namespace fs = boost::filesystem;
+
+namespace {
+struct Orientation
+{
+	std::string name;
+	eOrientation tag;
+};
+
+const std::array<Orientation, 4> _OrientationNames = {
+		Orientation{"no change", eOrientation::noChange},
+		Orientation{"Axial", eOrientation::RAS},
+		Orientation{"Sagittal", eOrientation::PSL},
+		Orientation{"Coronal", eOrientation::RSP}};
+
+class FileSystemModel : public QFileSystemModel
+{
+public:
+	FileSystemModel(QObject* parent = nullptr) : QFileSystemModel(parent) {}
+
+	QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
+	{
+		if (role == Qt::DisplayRole && index.column() == 0)
+		{
+			QString path = QDir::toNativeSeparators(filePath(index));
+			if (path.endsWith(QDir::separator()))
+				path.chop(1);
+			return path;
+		}
+
+		return QFileSystemModel::data(index, role);
+	}
+};
+} // namespace
+
+DataIteratorWidget::DataIteratorWidget(iseg::SlicesHandler* hand3D, QWidget* parent,
+		Qt::WindowFlags wFlags)
+		: QWidget(parent, wFlags), m_Handler3D(hand3D)
+{
+	setToolTip(Format("Dataset Iterator. Quickly review and edit large dataset."));
+
+	QCompleter* completer = new QCompleter(this);
+	completer->setMaxVisibleItems(10);
+	auto fs_model = new FileSystemModel(completer);
+	fs_model->setRootPath("");
+	completer->setModel(fs_model);
+
+	m_ImageDir = new QLineEdit;
+	m_ImageDir->setCompleter(completer);
+
+	m_LabelsDir = new QLineEdit;
+	m_LabelsDir->setCompleter(completer);
+
+	m_OutputDir = new QLineEdit;
+	m_OutputDir->setCompleter(completer);
+
+	m_TargetDir = new QLineEdit;
+	m_TargetDir->setCompleter(completer);
+
+	m_Status = new QLabel("none");
+	m_CurrentPairEdit = new QLineEdit(QString::number(m_CurrentPair + 1));
+	m_CurrentPairEdit->setValidator(new QIntValidator(0, std::numeric_limits<int>::max()));
+
+	m_SaveButton = new QPushButton("Save");
+	m_SaveButton->setToolTip("Save local changes to the labels to the 'Processed Output' folder.");
+	m_SaveMarksButton = new QPushButton("Save Marks");
+	m_SaveMarksButton->setToolTip("Save local changes to the labels to the 'Processed Output' folder.");
+	m_NextButton = new QPushButton("Next");
+	m_NextButton->setToolTip("Load next image/label pair.");
+	m_NextUnprocessedButton = new QPushButton("Next Unprocessed");
+	m_NextUnprocessedButton->setToolTip("Load next unprocessed image/label pair.");
+	m_LoadProcessed = new QCheckBox("Load Processed");
+	m_LoadProcessed->setChecked(true);
+	m_LoadProcessed->setToolTip("Load labels from 'Processed Output' if it exists.");
+
+	m_Orientation = new QComboBox;
+	for (auto& o : _OrientationNames)
+	{
+		m_Orientation->addItem(QString::fromStdString(o.name));
+	}
+	m_Orientation->setCurrentIndex(1);
+	m_Orientation->setToolTip("Reload the image/labels in the selected orientation.");
+
+	auto layout = new QFormLayout;
+	layout->addRow("Images", m_ImageDir);
+	layout->addRow("Labels", m_LabelsDir);
+	layout->addRow("Processed Output", m_OutputDir);
+	layout->addRow("Target [Optional]", m_TargetDir);
+	layout->addRow("Current Dataset", m_CurrentPairEdit);
+	layout->addRow("Status", m_Status);
+	layout->addRow("Orientation", m_Orientation);
+	layout->addRow(m_SaveButton, make_hbox({m_SaveMarksButton, m_NextButton}));
+	layout->addRow(m_NextUnprocessedButton, m_LoadProcessed);
+	setLayout(layout);
+
+	QObject::connect(m_SaveButton, SIGNAL(clicked()), this, SLOT(Save()));
+	QObject::connect(m_SaveMarksButton, SIGNAL(clicked()), this, SLOT(SaveMarks()));
+	QObject::connect(m_NextButton, SIGNAL(clicked()), this, SLOT(Next()));
+	QObject::connect(m_NextUnprocessedButton, SIGNAL(clicked()), this, SLOT(NextUnprocessed()));
+	QObject::connect(m_CurrentPairEdit, SIGNAL(editingFinished()), this, SLOT(CurrentPairChanged()));
+	QObject::connect(m_LoadProcessed, SIGNAL(stateChanged(int)), this, SLOT(Reload()));
+	QObject::connect(m_Orientation, SIGNAL(currentIndexChanged(int)), this, SLOT(ReloadOrientation()));
+}
+
+void DataIteratorWidget::LoadNext(bool skip_processed)
+{
+	int current_pair = m_CurrentPair;
+	// check if folders changed
+	if (m_CachedImageDir != m_ImageDir->text().toStdString() || m_CachedLabelsDir != m_LabelsDir->text().toStdString())
+	{
+		m_CachedImageDir = m_ImageDir->text().toStdString();
+		m_CachedLabelsDir = m_LabelsDir->text().toStdString();
+		m_ImageLabelPairs.clear();
+		m_FileTime.Modified();
+		current_pair = -1;
+
+		fs::directory_iterator dir_itr(m_CachedImageDir);
+		fs::directory_iterator end_iter;
+		for (; dir_itr != end_iter; ++dir_itr)
+		{
+			fs::path image_path(dir_itr->path());
+			fs::path labels_path = fs::path(m_CachedLabelsDir) / image_path.filename();
+
+			const std::vector<std::string> valid_extensions = {".mhd", ".mha", ".nii", ".hdr", ".img", ".gz", ".nrrd"};
+			const auto ext = image_path.extension().string();
+			boost::system::error_code ec;
+
+			if (std::count(valid_extensions.begin(), valid_extensions.end(), ext) != 0)
+			{
+				if (fs::exists(labels_path, ec))
+				{
+					m_ImageLabelPairs.emplace_back(image_path.string(), labels_path.string());
+				}
+			}
+		}
+	}
+
+	if (m_ImageLabelPairs.empty())
+	{
+		m_Status->setText("[0/0] No image/label pairs");
+	}
+	else if (current_pair + 1 < static_cast<int>(m_ImageLabelPairs.size()))
+	{
+		current_pair++;
+
+		if (skip_processed)
+		{
+			const auto output_dir = fs::path(m_OutputDir->text().toStdString());
+			auto exist_output = [this, output_dir, &current_pair]() {
+				const auto file_name = fs::path(m_ImageLabelPairs.at(current_pair).second).filename();
+				const fs::path processed_path = output_dir / file_name;
+				boost::system::error_code ec;
+				return fs::exists(processed_path, ec);
+			};
+
+			while (exist_output() && current_pair + 1 < static_cast<int>(m_ImageLabelPairs.size()))
+			{
+				current_pair++;
+			}
+		}
+	}
+
+	if (current_pair < static_cast<int>(m_ImageLabelPairs.size()))
+	{
+		Load(current_pair);
+	}
+	else
+	{
+		if (!m_Status->text().contains("(The END)"))
+		{
+			m_Status->setText(m_Status->text() + " (The END)");
+		}
+	}
+}
+
+void DataIteratorWidget::Load(int pair_idx)
+{
+	if (m_FileTime < m_Handler3D->ModifyTime())
+	{
+		const int ret = QMessageBox::warning(
+				this, "iSeg", "Detected unsaved modifications. Do you want to save your changes?",
+				QMessageBox::Yes | QMessageBox::Default, QMessageBox::No,
+				QMessageBox::Cancel | QMessageBox::Escape);
+
+		if (ret == QMessageBox::Yes)
+		{
+			Save();
+		}
+		else if (ret == QMessageBox::Cancel)
+		{
+			return;
+		}
+	}
+
+	if (pair_idx < static_cast<int>(m_ImageLabelPairs.size()))
+	{
+		const auto image_path = m_ImageLabelPairs[pair_idx].first;
+		const auto labels_path = m_ImageLabelPairs[pair_idx].second;
+		const auto processed_path = fs::path(m_OutputDir->text().toStdString()) / fs::path(labels_path).filename();
+		const auto target_path = fs::path(m_TargetDir->text().toStdString()) / fs::path(labels_path).filename();
+		const auto slice = m_Handler3D->ActiveSlice();
+
+		boost::system::error_code ec;
+		if (!fs::exists(image_path) || !fs::exists(labels_path))
+		{
+			QMessageBox msgBox;
+			msgBox.setText("ERROR: image/label files could not be found.");
+			msgBox.exec();
+			return;
+		}
+
+		//
+		const auto orientation = static_cast<int>(_OrientationNames.at(m_Orientation->currentIndex()).tag);
+
+		iseg::DataSelection dataSelection;
+		dataSelection.allSlices = true;
+		dataSelection.bmp = true;
+		dataSelection.work = true;
+		dataSelection.tissues = true;
+		emit BeginDatachange(dataSelection, this, false);
+
+		// read labels
+		const auto load_processed = m_LoadProcessed->isChecked() && fs::exists(processed_path, ec);
+		m_Handler3D->ReadVolumeOrient(load_processed ? processed_path.string() : labels_path, true, orientation);
+
+		// read target
+		if (!m_TargetDir->text().isEmpty() && fs::exists(target_path, ec))
+		{
+			m_Handler3D->ReadVolumeOrient(target_path.string(), false, orientation);
+			m_Handler3D->Bmp2workall();
+		}
+
+		// read image
+		m_Handler3D->ReadVolumeOrient(image_path, false, orientation);
+
+		emit EndDatachange(this, iseg::ClearUndo);
+
+		// update GUI
+		m_Handler3D->SignalVolumeChange(true);
+
+		// try to stay at similar position
+		m_Handler3D->SetActiveSlice(slice, true);
+
+		// update gui
+		auto file_name = fs::path(labels_path).filename().string();
+		auto status = "[" + std::to_string(pair_idx + 1) + "/" + std::to_string(m_ImageLabelPairs.size()) + "] ";
+		m_Status->setText((status + file_name).c_str());
+
+		if (!load_processed && fs::exists(processed_path, ec))
+		{
+			m_Status->setText(m_Status->text() + " Already Processed");
+			m_Status->setStyleSheet("QLabel  { color: red; }");
+		}
+		else
+		{
+			m_Status->setStyleSheet("");
+		}
+
+		m_FileTime.Modified();
+		m_CurrentPair = pair_idx; // 'pair_idx' was loaded -> save its index
+		m_CurrentPairEdit->setText(QString::number(m_CurrentPair + 1));
+	}
+}
+
+void DataIteratorWidget::Save()
+{
+	if (m_CurrentPair >= 0 && m_CurrentPair < static_cast<int>(m_ImageLabelPairs.size()))
+	{
+		const fs::path output_dir(m_OutputDir->text().toStdString());
+		boost::system::error_code ec;
+		if (!fs::exists(output_dir, ec))
+		{
+			fs::create_directory(output_dir, ec);
+		}
+
+		const fs::path image_path(m_ImageLabelPairs[m_CurrentPair].first);
+		const fs::path output_file_path = output_dir / image_path.filename();
+
+		if (!m_LoadProcessed->isChecked() && fs::exists(output_file_path))
+		{
+			const int ret = QMessageBox::warning(
+					this, "iSeg", "The output file exists. Do you want to overwrite it with your changes?",
+					QMessageBox::Yes, QMessageBox::Cancel | QMessageBox::Escape | QMessageBox::Default);
+
+			if (ret == QMessageBox::Cancel)
+			{
+				ISEG_WARNING("Cancelled saving " << m_CurrentPair + 1);
+				return;
+			}
+		}
+
+		using tissue_image_t = itk::Image<iseg::SlicesHandlerITKInterface::tissue_type, 3>;
+		iseg::SlicesHandlerITKInterface itk_handler(m_Handler3D);
+
+		tissue_image_t::Pointer tissues = itk_handler.GetTissuesDeprecated(false);
+
+		const auto orientation = _OrientationNames.at(m_Orientation->currentIndex()).tag;
+		if (orientation != eOrientation::noChange)
+		{
+			// load input orientation
+			auto reader = itk::ImageFileReader<tissue_image_t>::New();
+			reader->SetFileName(image_path.string());
+			reader->UpdateOutputInformation();
+
+			auto image = reader->GetOutput();
+			const itk::DICOMOrientation input_orientation(image->GetDirection());
+
+			auto orient = itk::DICOMOrientImageFilter<tissue_image_t>::New();
+			orient->SetInput(tissues);
+			orient->SetDesiredCoordinateOrientation(input_orientation);
+			orient->Update();
+			tissues = orient->GetOutput();
+		}
+
+		auto writer = itk::ImageFileWriter<tissue_image_t>::New();
+		writer->SetInput(tissues);
+		writer->SetFileName(output_file_path.string());
+		writer->SetUseCompression(true);
+		writer->Update();
+
+		m_FileTime.Modified();
+		ISEG_INFO("Saved " << output_file_path.string());
+	}
+	else
+	{
+		ISEG_ERROR("Invalid data index " << m_CurrentPair + 1);
+	}
+}
+
+void DataIteratorWidget::SaveMarks()
+{
+	if (m_CurrentPair >= 0 && m_CurrentPair < static_cast<int>(m_ImageLabelPairs.size()))
+	{
+		const fs::path output_dir(m_OutputDir->text().toStdString());
+		boost::system::error_code ec;
+		if (!fs::exists(output_dir, ec))
+		{
+			fs::create_directory(output_dir, ec);
+		}
+
+		const fs::path image_path(m_ImageLabelPairs[m_CurrentPair].first);
+		const fs::path marks_file_path = output_dir / image_path.stem().concat(".csv");
+
+		m_Handler3D->ExportMarkers(marks_file_path.string().c_str());
+
+		ISEG_INFO("Saved marks " << marks_file_path.string());
+	}
+	else
+	{
+		ISEG_ERROR("Invalid data index " << m_CurrentPair + 1);
+	}
+}
+
+void DataIteratorWidget::Next()
+{
+	LoadNext(false);
+}
+
+void DataIteratorWidget::NextUnprocessed()
+{
+	LoadNext(true);
+}
+
+void DataIteratorWidget::CurrentPairChanged()
+{
+	bool ok = false;
+	const int new_idx = m_CurrentPairEdit->text().toInt(&ok) - 1;
+	if (ok && static_cast<size_t>(new_idx) < m_ImageLabelPairs.size())
+	{
+		Load(new_idx);
+	}
+	else
+	{
+		ISEG_ERROR("Invalid index: " << m_CurrentPairEdit->text().toStdString());
+		m_CurrentPairEdit->setText(QString::number(m_CurrentPair + 1));
+	}
+}
+
+void DataIteratorWidget::Reload()
+{
+	Load(m_CurrentPair);
+}
+
+void DataIteratorWidget::ReloadOrientation()
+{
+	const auto temp_dir = fs::temp_directory_path();
+	auto pts_file_path = temp_dir / "marks.pts";
+	m_Handler3D->ExportMarkers(pts_file_path.string().c_str());
+
+	Load(m_CurrentPair);
+
+	m_Handler3D->ImportMarkers(pts_file_path.string().c_str());
+	fs::remove(pts_file_path);
+}
+
+} // namespace iseg

--- a/iSeg/DataIteratorWidget.h
+++ b/iSeg/DataIteratorWidget.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 The Foundation for Research on Information Technologies in
+ Society (IT'IS).
+ *
+ * This file is part of iSEG
+ * (see https://github.com/ITISFoundation/osparc-iseg).
+ *
+ * This software is released under the MIT License.
+ *  https://opensource.org/licenses/MIT
+ */
+#pragma once
+
+#include "../Data/DataSelection.h"
+#include "../Data/TimeStamp.h"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+
+#include <map>
+
+namespace iseg {
+
+class SlicesHandler;
+
+class DataIteratorWidget : public QWidget
+{
+	Q_OBJECT
+public:
+	DataIteratorWidget(iseg::SlicesHandler* hand3D, QWidget* parent = nullptr,
+			Qt::WindowFlags wFlags = Qt::WindowFlags());
+	~DataIteratorWidget() override = default;
+
+private:
+	void LoadNext(bool skip_processed);
+	void Load(int pair_idx);
+
+private:
+	iseg::SlicesHandler* m_Handler3D;
+
+	QLineEdit* m_ImageDir;
+	QLineEdit* m_LabelsDir;
+	QLineEdit* m_OutputDir;
+	QLineEdit* m_TargetDir;
+	QLineEdit* m_CurrentPairEdit;
+	QCheckBox* m_LoadProcessed;
+	QLabel* m_Status;
+
+	QPushButton* m_SaveButton;
+	QPushButton* m_SaveMarksButton;
+	QPushButton* m_NextButton;
+	QPushButton* m_NextUnprocessedButton;
+
+	QComboBox* m_Orientation;
+
+	std::string m_CachedImageDir;
+	std::string m_CachedLabelsDir;
+	int m_CurrentPair = -1;
+	TimeStamp m_FileTime;
+	std::vector<std::pair<std::string, std::string>> m_ImageLabelPairs;
+
+signals:
+	void BeginDatachange(iseg::DataSelection& dataSelection,
+			QWidget* sender = nullptr, bool beginUndo = true);
+	void EndDatachange(QWidget* sender = nullptr,
+			iseg::eEndUndoAction undoAction = iseg::EndUndo);
+
+private slots:
+	void Save();
+	void SaveMarks();
+	void Next();
+	void NextUnprocessed();
+	void CurrentPairChanged();
+	void Reload();
+	void ReloadOrientation();
+};
+
+} // namespace iseg

--- a/iSeg/MainWindow.cpp
+++ b/iSeg/MainWindow.cpp
@@ -13,6 +13,7 @@
 
 #include "ActiveSlicesConfigDialog.h"
 #include "AtlasWidget.h"
+#include "DataIteratorWidget.h"
 #include "EdgeWidget.h"
 #include "FastmarchingFuzzyWidget.h"
 #include "FeatureWidget.h"
@@ -361,6 +362,23 @@ MainWindow::MainWindow(SlicesHandler* hand3D, const QString& locationstring, con
 		SliceChanged();
 	});
 
+	m_Handler3D->m_OnVolumeChanged.connect([this](bool update_tissues) {
+		PixelsizeChanged();
+		SlicethicknessChanged();
+		ResetBrightnesscontrast();
+
+		if (update_tissues)
+		{
+			tissues_size_t m;
+			m_Handler3D->GetRangetissue(&m);
+			m_Handler3D->Buildmissingtissues(m);
+			m_TissueTreeWidget->UpdateTreeWidget();
+
+			tissues_size_t curr_tissue_type = m_TissueTreeWidget->GetCurrentType();
+			TissuenrChanged(curr_tissue_type - 1);
+		}
+	});
+
 	if (!m_Handler3D->Isloaded())
 	{
 		m_Handler3D->Newbmp(512, 512, 10);
@@ -669,6 +687,7 @@ MainWindow::MainWindow(SlicesHandler* hand3D, const QString& locationstring, con
 	m_BitstackWidget = new BitsStack(m_Handler3D, this);
 	m_OverlayWidget = new ExtoverlayWidget(m_Handler3D, this);
 	m_MultidatasetWidget = new MultiDatasetWidget(m_Handler3D, this);
+	m_DataIteratorWidget = new DataIteratorWidget(m_Handler3D, this);
 
 	int height_max1 = height_max;
 
@@ -896,6 +915,12 @@ MainWindow::MainWindow(SlicesHandler* hand3D, const QString& locationstring, con
 	multi_dataset_dock->setAllowedAreas(Qt::TopDockWidgetArea | Qt::BottomDockWidgetArea);
 	multi_dataset_dock->setWidget(m_MultidatasetWidget);
 	addDockWidget(Qt::BottomDockWidgetArea, multi_dataset_dock);
+
+	auto data_iterator_dock = new QDockWidget(tr("Data Iterator"), this);
+	data_iterator_dock->setObjectName("Data Iterator");
+	data_iterator_dock->setAllowedAreas(Qt::TopDockWidgetArea | Qt::BottomDockWidgetArea);
+	data_iterator_dock->setWidget(m_DataIteratorWidget);
+	addDockWidget(Qt::BottomDockWidgetArea, data_iterator_dock);
 
 	QDockWidget* overlaydock = new QDockWidget(tr("Overlay"), this);
 	overlaydock->setObjectName("Overlay");
@@ -1418,6 +1443,8 @@ MainWindow::MainWindow(SlicesHandler* hand3D, const QString& locationstring, con
 	QObject_connect(m_MultidatasetWidget, SIGNAL(DatasetChanged()), this, SLOT(DatasetChanged()));
 	QObject_connect(m_MultidatasetWidget, SIGNAL(BeginDatachange(DataSelection&,QWidget*,bool)), this, SLOT(HandleBeginDatachange(DataSelection&,QWidget*,bool)));
 	QObject_connect(m_MultidatasetWidget, SIGNAL(EndDatachange(QWidget*,eEndUndoAction)), this, SLOT(HandleEndDatachange(QWidget*,eEndUndoAction)));
+	QObject_connect(m_DataIteratorWidget, SIGNAL(BeginDatachange(DataSelection&,QWidget*,bool)), this, SLOT(HandleBeginDatachange(DataSelection&,QWidget*,bool)));
+	QObject_connect(m_DataIteratorWidget, SIGNAL(EndDatachange(QWidget*,eEndUndoAction)), this, SLOT(HandleEndDatachange(QWidget*,eEndUndoAction)));
 
 	QObject_connect(m_CbTissuelock, SIGNAL(clicked()), this, SLOT(TissuelockToggled()));
 

--- a/iSeg/MainWindow.h
+++ b/iSeg/MainWindow.h
@@ -50,6 +50,7 @@ class TissueTreeWidget;
 class TissueHierarchyWidget;
 class BitsStack;
 class ExtoverlayWidget;
+class DataIteratorWidget;
 class MultiDatasetWidget;
 class ScaleWork;
 class ImageMath;
@@ -247,6 +248,7 @@ private:
 	BitsStack* m_BitstackWidget;
 	ExtoverlayWidget* m_OverlayWidget;
 	MultiDatasetWidget* m_MultidatasetWidget;
+	DataIteratorWidget* m_DataIteratorWidget;
 	QCheckBox* m_CbBmptissuevisible;
 	QCheckBox* m_CbBmpcrosshairvisible;
 	QCheckBox* m_CbBmpoutlinevisible;

--- a/iSeg/SlicesHandler.cpp
+++ b/iSeg/SlicesHandler.cpp
@@ -762,7 +762,10 @@ bool SlicesHandler::ReadVolume(const std::string& file_path, bool tissue)
 			slices[i] = tissue ? m_ImageSlices[i].ReturnWork() : m_ImageSlices[i].ReturnBmp();
 		}
 
-		ImageReader::GetVolume(file_path, slices.data(), m_Nrslices, m_Width, m_Height);
+		if (!ImageReader::GetVolume(file_path, slices.data(), m_Nrslices, m_Width, m_Height))
+		{
+			return false;
+		}
 
 		if (tissue)
 		{
@@ -810,7 +813,10 @@ bool SlicesHandler::ReadVolumeOrient(const std::string& file_path, bool tissue, 
 			slices[i] = tissue ? m_ImageSlices[i].ReturnWork() : m_ImageSlices[i].ReturnBmp();
 		}
 
-		ImageReader::CopySlices(buffer, slices.data(), 0, m_Nrslices, m_Width, m_Height);
+		if (!ImageReader::CopySlices(buffer, slices.data(), 0, m_Nrslices, m_Width, m_Height))
+		{
+			return false;
+		}
 
 		if (tissue)
 		{
@@ -3262,9 +3268,8 @@ bool SlicesHandler::ImportMarkers(const char* filename)
 		{
 			int num_landmarks = 0;
 			std::string line;
-			for (size_t line_idx = 0; !ifs.eof(); ++line_idx)
+			for (size_t line_idx = 0; std::getline(ifs, line); ++line_idx)
 			{
-				std::getline(ifs, line);
 				alg::trim(line);
 
 				std::vector<std::string> tokens;
@@ -3301,7 +3306,7 @@ bool SlicesHandler::ImportMarkers(const char* filename)
 		}
 		catch (const std::exception& e)
 		{
-			ISEG_ERROR("Failed to load markers" << e.what());
+			ISEG_ERROR("Failed to load markers: " << e.what());
 			return false;
 		}
 

--- a/iSeg/SlicesHandler.cpp
+++ b/iSeg/SlicesHandler.cpp
@@ -28,6 +28,7 @@
 #include "vtkImageExtractCompatibleMesher.h"
 
 #include "Data/ItkProgressObserver.h"
+#include "Data/ScopeExit.h"
 #include "Data/SlicesHandlerITKInterface.h"
 #include "Data/Transform.h"
 
@@ -71,12 +72,16 @@
 
 #include <itkConnectedComponentImageFilter.h>
 
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 #include <QDir>
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QProgressDialog>
+
+#include <fstream>
 
 #ifndef NO_OPENMP_SUPPORT
 #	include <omp.h>
@@ -726,6 +731,101 @@ int SlicesHandler::ReadImage(const char* filename)
 		return 1;
 	}
 	return 0;
+}
+
+bool SlicesHandler::ReadVolume(const std::string& file_path, bool tissue)
+{
+	if (!tissue)
+	{
+		UpdateColorLookupTable(nullptr);
+	}
+
+	unsigned w, h, nrofslices;
+	float spacing1[3];
+	Transform transform1;
+	if (ImageReader::GetInfo(file_path, w, h, nrofslices, spacing1, transform1))
+	{
+		m_Thickness = spacing1[2];
+		m_Dx = spacing1[0];
+		m_Dy = spacing1[1];
+		m_Transform = transform1;
+
+		// only re-allocate if size changed
+		if (w != m_Width || h != m_Height || nrofslices != m_Nrslices)
+		{
+			Newbmp(w, h, nrofslices);
+		}
+
+		std::vector<float*> slices(m_Nrslices);
+		for (unsigned i = 0; i < m_Nrslices; i++)
+		{
+			slices[i] = tissue ? m_ImageSlices[i].ReturnWork() : m_ImageSlices[i].ReturnBmp();
+		}
+
+		ImageReader::GetVolume(file_path, slices.data(), m_Nrslices, m_Width, m_Height);
+
+		if (tissue)
+		{
+			Work2tissueall();
+
+			tissues_size_t m;
+			GetRangetissue(&m);
+			Buildmissingtissues(m);
+
+			ClearWork();
+		}
+		m_Loaded = true;
+		return true;
+	}
+	return false;
+}
+
+bool SlicesHandler::ReadVolumeOrient(const std::string& file_path, bool tissue, int orientation)
+{
+	if (!tissue)
+	{
+		UpdateColorLookupTable(nullptr);
+	}
+
+	unsigned w, h, nrofslices;
+	float spacing1[3];
+	Transform transform1;
+	std::vector<float> buffer;
+	if (ImageReader::GetVolume(file_path, buffer, w, h, nrofslices, spacing1, transform1, static_cast<eOrientation>(orientation)))
+	{
+		m_Thickness = spacing1[2];
+		m_Dx = spacing1[0];
+		m_Dy = spacing1[1];
+		m_Transform = transform1;
+
+		// only re-allocate if size changed
+		if (w != m_Width || h != m_Height || nrofslices != m_Nrslices)
+		{
+			Newbmp(w, h, nrofslices);
+		}
+
+		std::vector<float*> slices(m_Nrslices);
+		for (unsigned i = 0; i < m_Nrslices; i++)
+		{
+			slices[i] = tissue ? m_ImageSlices[i].ReturnWork() : m_ImageSlices[i].ReturnBmp();
+		}
+
+		ImageReader::CopySlices(buffer, slices.data(), 0, m_Nrslices, m_Width, m_Height);
+
+		if (tissue)
+		{
+			Work2tissueall();
+
+			tissues_size_t m;
+			GetRangetissue(&m);
+			Buildmissingtissues(m);
+
+			ClearWork();
+		}
+		m_Loaded = true;
+		return true;
+	}
+	return false;
 }
 
 int SlicesHandler::ReadOverlay(const char* filename, unsigned short slicenr)
@@ -3092,6 +3192,139 @@ void SlicesHandler::GetLabels(std::vector<AugmentedMark>* labels)
 			labels->push_back(am);
 		}
 	}
+}
+
+bool SlicesHandler::ExportMarkers(const char* filename)
+{
+	const auto tx = ImageTransform();
+	const auto sp = Spacing();
+
+	std::vector<std::pair<Vec3, Mark>> points;
+
+	for (unsigned i = m_Startslice; i < m_Endslice; i++)
+	{
+		const std::vector<Mark>& marks = *(m_ImageSlices[i].ReturnMarks());
+		for (const auto& mark : marks)
+		{
+			const Vec3 p = {mark.p.px * sp[0], mark.p.py * sp[1], i * sp[2]};
+			points.push_back({tx.RigidTransformPoint(p), mark});
+		}
+	}
+
+	auto fp = fopen(filename, "w");
+	if (fp)
+	{
+		const auto ext = boost::filesystem::path(filename).extension().string();
+		if (ext == ".csv")
+		{
+			fprintf(fp, "# X, Y, Z, Label\n");
+			for (const auto& m : points)
+			{
+				fprintf(fp, "%g, %g, %g, %d\n", m.first[0], m.first[1], m.first[2], m.second.mark);
+			}
+		}
+		else // .pts format
+		{
+			fprintf(fp, "Version 1.0\n");
+			fprintf(fp, "%d\n", static_cast<int>(points.size()));
+			for (size_t idx = 0; idx < points.size(); ++idx)
+			{
+				const auto& m = points[idx];
+				auto name = m.second.name;
+				if (name.empty())
+				{
+					name = "Point " + std::to_string(idx + 1);
+				}
+				fprintf(fp, "%s %g %g %g\n", name.c_str(), m.first[0], m.first[1], m.first[2]);
+			}
+		}
+
+		fclose(fp);
+		return true;
+	}
+	return false;
+}
+
+bool SlicesHandler::ImportMarkers(const char* filename)
+{
+	namespace alg = boost::algorithm;
+	namespace fs = boost::filesystem;
+
+	std::vector<std::pair<std::string, Vec3>> landmarks;
+
+	const auto file_path = fs::path(filename).string();
+	std::ifstream ifs(file_path);
+	if (ifs.is_open())
+	{
+		auto ifs_guard = MakeScopeExit([&ifs]() { ifs.close(); });
+
+		try
+		{
+			int num_landmarks = 0;
+			std::string line;
+			for (size_t line_idx = 0; !ifs.eof(); ++line_idx)
+			{
+				std::getline(ifs, line);
+				alg::trim(line);
+
+				std::vector<std::string> tokens;
+				boost::split(tokens, line, boost::is_any_of("\t "), boost::token_compress_on);
+				if (line_idx == 0)
+				{
+					std::transform(line.begin(), line.end(), line.begin(), ::tolower);
+					if (tokens.size() != 2 || !alg::starts_with(line, "version 1"))
+						throw std::runtime_error("Expecting 'Version 1.0' on first line");
+				}
+				else if (line_idx == 1)
+				{
+					if (tokens.size() != 1)
+						throw std::runtime_error("Second line should contain the number of landmarks");
+
+					num_landmarks = atoi(tokens[0].c_str());
+				}
+				else
+				{
+					if (tokens.size() >= 4)
+					{
+						const auto n = tokens.size();
+						const auto x = atof(tokens[n - 3].c_str());
+						const auto y = atof(tokens[n - 2].c_str());
+						const auto z = atof(tokens[n - 1].c_str());
+
+						tokens.resize(n - 3);
+						const auto name = boost::join(tokens, " ");
+
+						landmarks.push_back(std::make_pair(name, Vec3(x, y, z)));
+					}
+				}
+			}
+		}
+		catch (const std::exception& e)
+		{
+			ISEG_ERROR("Failed to load markers" << e.what());
+			return false;
+		}
+
+		const auto tx = ImageTransform();
+		const auto sp = Spacing();
+
+		auto m = tx.ToVector();
+		vtkNew<vtkTransform> inverse_transform;
+		inverse_transform->SetMatrix(m.data());
+		inverse_transform->Inverse();
+
+		for (const auto& p : landmarks)
+		{
+			const auto pt = inverse_transform->TransformFloatPoint(p.second.v);
+			const short idx[3] = {
+					static_cast<short>(std::min(static_cast<int>(Width()) - 1, std::max(0, static_cast<int>(std::round(pt[0] / sp[0]))))),
+					static_cast<short>(std::min(static_cast<int>(Height()) - 1, std::max(0, static_cast<int>(std::round(pt[1] / sp[1]))))),
+					static_cast<short>(std::min(static_cast<int>(NumSlices()) - 1, std::max(0, static_cast<int>(std::round(pt[2] / sp[2])))))};
+			AddMark({idx[0], idx[1]}, Mark::red, idx[2], p.first);
+		}
+		return true;
+	}
+	return false;
 }
 
 void SlicesHandler::AddVm(std::vector<Mark>* vm1)

--- a/iSeg/SlicesHandler.h
+++ b/iSeg/SlicesHandler.h
@@ -79,6 +79,11 @@ public:
 	int ReadRTdose(const char* filename);
 	bool LoadSurface(const std::string& filename, bool overwrite_working, bool intersect);
 
+	bool ReadVolume(const std::string& file_path, bool tissue) override;
+	bool ReadVolumeOrient(const std::string& file_path, bool tissue, int orientation);
+	bool ExportMarkers(const char* filename);
+	bool ImportMarkers(const char* filename);
+
 	int LoadAllXdmf(const char* filename);
 	int LoadAllHDF(const char* filename);
 
@@ -311,7 +316,9 @@ public:
 
 	unsigned short ActiveSlice() const override;
 	boost::signals2::signal<void(unsigned short)> m_OnActiveSliceChanged;
+	boost::signals2::signal<void(bool)> m_OnVolumeChanged;
 	void SetActiveSlice(unsigned short slice, bool signal_change = false) override;
+	void SignalVolumeChange(bool update_tissues) override { m_OnVolumeChanged(update_tissues); }
 
 	Bmphandler* GetActivebmphandler();
 	tissuelayers_size_t ActiveTissuelayer() const override;

--- a/iSeg/SurfaceViewerWidget.cpp
+++ b/iSeg/SurfaceViewerWidget.cpp
@@ -43,6 +43,7 @@
 #include <vtkQuadricLODActor.h>
 #include <vtkRenderWindow.h>
 #include <vtkRenderer.h>
+#include <vtkTransform.h>
 
 #include <vtkAutoInit.h>
 #ifdef ISEG_VTK_OPENGL2
@@ -173,6 +174,8 @@ SurfaceViewerWidget::SurfaceViewerWidget(SlicesHandler* hand3D1, eInputType inpu
 	m_Ren3D = vtkSmartPointer<vtkRenderer>::New();
 	m_Ren3D->SetBackground(0, 0, 0);
 	m_Ren3D->SetViewport(0.0, 0.0, 1.0, 1.0);
+	m_Ren3D->SetLightFollowCamera(true);
+	m_Ren3D->SetTwoSidedLighting(true);
 
 	m_VtkWidget->GetRenderWindow()->AddRenderer(m_Ren3D);
 	m_VtkWidget->GetRenderWindow()->LineSmoothingOn();
@@ -182,6 +185,7 @@ SurfaceViewerWidget::SurfaceViewerWidget(SlicesHandler* hand3D1, eInputType inpu
 	m_Iren = vtkSmartPointer<QVTKInteractor>::New();
 	m_Iren->SetInteractorStyle(m_Style);
 	m_Iren->SetRenderWindow(m_VtkWidget->GetRenderWindow());
+	m_Iren->SetLightFollowCamera(false);
 
 	QMenu* popup_actions = new QMenu(m_VtkWidget);
 	popup_actions->addAction("Select tissue")->setData(eActions::kSelectTissue);
@@ -195,7 +199,9 @@ SurfaceViewerWidget::SurfaceViewerWidget(SlicesHandler* hand3D1, eInputType inpu
 	// copy input data and setup VTK pipeline
 	m_Input = vtkSmartPointer<vtkImageData>::New();
 	m_DiscreteCubes = vtkSmartPointer<vtkDiscreteFlyingEdges3D>::New();
+	m_DiscreteCubes->SetComputeNormals(false);
 	m_Cubes = vtkSmartPointer<vtkFlyingEdges3D>::New();
+	m_Cubes->SetComputeNormals(false);
 	m_Decimate = vtkSmartPointer<vtkDecimatePro>::New();
 	m_Decimate->PreserveTopologyOn();
 	m_Decimate->BoundaryVertexDeletionOff();
@@ -220,6 +226,13 @@ void SurfaceViewerWidget::Load()
 {
 	auto tissue_selection = m_Hand3D->TissueSelection();
 	auto spacing = m_Hand3D->Spacing();
+	auto transform = m_Hand3D->ImageTransform().ToVector();
+	auto vtk_transform = vtkSmartPointer<vtkTransform>::New();
+	vtk_transform->SetMatrix(transform.data());
+
+	auto mirror = m_Hand3D->ImageTransform().HasFlip();
+	ISEG_INFO("The transform is mirrored: " << mirror);
+
 	size_t slice_size = static_cast<size_t>(m_Hand3D->Width()) * m_Hand3D->Height();
 
 	m_Input->SetExtent(0, (int)m_Hand3D->Width() - 1, 0, (int)m_Hand3D->Height() - 1, 0, (int)m_Hand3D->NumSlices() - 1);
@@ -329,8 +342,10 @@ void SurfaceViewerWidget::Load()
 	}
 
 	m_Actor->GetProperty()->SetOpacity(1.0 - 0.01 * m_SlTrans->value());
+	m_Actor->GetProperty()->SetBackfaceCulling(false);
 
 	m_Actor->SetMapper(m_Mapper);
+	m_Actor->SetUserMatrix(vtk_transform->GetMatrix());
 	m_Ren3D->AddActor(m_Actor);
 }
 
@@ -447,21 +462,31 @@ void SurfaceViewerWidget::SelectAction(QAction* action)
 		{
 			if (m_Input)
 			{
-				double* world_position = m_Picker->GetPickPosition();
+				auto transform = m_Hand3D->ImageTransform().ToVector();
+				auto vtk_transform = vtkSmartPointer<vtkTransform>::New();
+				vtk_transform->SetMatrix(transform.data());
+				vtk_transform->Inverse();
+
+				double worldPosition[3];
+				m_Picker->GetPickPosition(worldPosition);
+
+				double imagePosition[3];
+				vtk_transform->TransformPoint(worldPosition, imagePosition);
+
 				int dims[3];
-				double spacing[3], origin[3];
+				double spacing[3];
 				m_Input->GetDimensions(dims);
 				m_Input->GetSpacing(spacing);
-				m_Input->GetOrigin(origin);
+
 				// compute closest slice
-				int slice = static_cast<int>(std::round((world_position[2] - origin[2]) / spacing[2]));
+				int slice = static_cast<int>(std::round((imagePosition[2]) / spacing[2]));
 				slice = std::max(0, std::min(slice, dims[2] - 1));
 
 				if (action->data() == eActions::kMarkPoint)
 				{
 					Point p;
-					p.px = static_cast<int>(std::round((world_position[0] - origin[0]) / spacing[0]));
-					p.py = static_cast<int>(std::round((world_position[1] - origin[1]) / spacing[1]));
+					p.px = static_cast<int>(std::round((imagePosition[0]) / spacing[0]));
+					p.py = static_cast<int>(std::round((imagePosition[1]) / spacing[1]));
 
 					DataSelection data_selection;
 					data_selection.sliceNr = slice;

--- a/iSeg/SurfaceViewerWidget.cpp
+++ b/iSeg/SurfaceViewerWidget.cpp
@@ -231,7 +231,6 @@ void SurfaceViewerWidget::Load()
 	vtk_transform->SetMatrix(transform.data());
 
 	auto mirror = m_Hand3D->ImageTransform().HasFlip();
-	ISEG_INFO("The transform is mirrored: " << mirror);
 
 	size_t slice_size = static_cast<size_t>(m_Hand3D->Width()) * m_Hand3D->Height();
 


### PR DESCRIPTION
- Add DataIteratorWidget for iterating through image volumes with orientation
- Add ITK DICOM orientation support (itkDICOMOrientation, itkDICOMOrientImageFilter)
- Add TimeStamp class for modification tracking
- Add Transform::HasFlip() and Transform::ToVector() methods
- Add ImageReader::GetVolume() overload with orientation resampling
- Add ImageReader::CopySlices() for buffer-to-slice copying
- Add SlicesHandler::ReadVolume(), ReadVolumeOrient(), ExportMarkers(), ImportMarkers()
- Add SlicesHandler::SignalVolumeChange() with boost::signals2 signal
- Fix SurfaceViewerWidget: add lighting, normals, transform and backface culling
- Integrate DataIteratorWidget as dock widget in MainWindow